### PR TITLE
Upgrade to BehaviorTree.CPP 4.1.1

### DIFF
--- a/include/example_behaviors/delayed_message.hpp
+++ b/include/example_behaviors/delayed_message.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <behaviortree_cpp_v3/action_node.h>
+#include <behaviortree_cpp/action_node.h>
 
 // This header includes the SharedResourcesNode type
 #include <moveit_studio_behavior_interface/shared_resources_node.hpp>

--- a/include/example_behaviors/hello_world.hpp
+++ b/include/example_behaviors/hello_world.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <behaviortree_cpp_v3/action_node.h>
+#include <behaviortree_cpp/action_node.h>
 
 // This header includes the SharedResourcesNode type
 #include <moveit_studio_behavior_interface/shared_resources_node.hpp>

--- a/include/example_behaviors/setup_mtc_wave_hand.hpp
+++ b/include/example_behaviors/setup_mtc_wave_hand.hpp
@@ -2,7 +2,7 @@
 
 #pragma once
 
-#include <behaviortree_cpp_v3/action_node.h>
+#include <behaviortree_cpp/action_node.h>
 #include <moveit_studio_behavior_interface/shared_resources_node.hpp>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/check_for_error.hpp>

--- a/src/delayed_message.cpp
+++ b/src/delayed_message.cpp
@@ -22,7 +22,7 @@ BT::NodeStatus DelayedMessage::onStart()
   // Store the time at which this node was first ticked
   start_time_ = std::chrono::steady_clock::now();
 
-  // getInput returns a BT::Optional so we'll store the result temporarily while we check if it was set correctly
+  // getInput returns a BT::Expected so we'll store the result temporarily while we check if it was set correctly
   const auto maybe_duration = getInput<double>("delay_duration");
 
   // The maybe_error function returns a std::optional with an error message if the port was set incorrectly

--- a/src/register_behaviors.cpp
+++ b/src/register_behaviors.cpp
@@ -1,4 +1,4 @@
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/bt_factory.h>
 #include <moveit_studio_behavior_interface/behavior_context.hpp>
 #include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
 

--- a/test/test_behavior_plugins.cpp
+++ b/test/test_behavior_plugins.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <behaviortree_cpp_v3/bt_factory.h>
+#include <behaviortree_cpp/bt_factory.h>
 #include <moveit_studio_behavior_interface/shared_resources_node_loader.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/node.hpp>


### PR DESCRIPTION
This PR just follows some of the other work done in the main MoveIt Studio repo to update BehaviorTree.CPP to v4.1.1. 